### PR TITLE
[feat-4]: Implements (some) ingestion methods

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
   "name": "Elixir Sonic Client",
   // Update the 'dockerComposeFile' list if you have more compose files or use different names.
   // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
-  "dockerComposeFile": ["docker-compose.yml"],
+  "dockerComposeFile": [
+    "docker-compose.yml"
+  ],
   // The 'service' property is the name of the service for the container that VS Code should
   // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
   "service": "elixir",
@@ -23,10 +25,17 @@
   "extensions": [
     "JakeBecker.elixir-ls",
     "ms-azuretools.vscode-docker",
-    "pantajoe.vscode-elixir-credo"
+    "pantajoe.vscode-elixir-credo",
+    "mhutchie.git-graph",
+    "eamodio.gitlens",
+    "donjayamanne.githistory",
+    "mohsen1.prettify-json",
+    "ms-vsliveshare.vsliveshare-pack"
   ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [4000],
+  "forwardPorts": [
+    4000
+  ],
   // "postCreateCommand": "sudo chown $USERNAME:$USERNAME assets/node_modules deps _build .elixir_ls",
   // Uncomment the next line if you want start specific services in your Docker Compose config.
   // "runServices": [],

--- a/lib/elixir_sonic_client.ex
+++ b/lib/elixir_sonic_client.ex
@@ -53,11 +53,19 @@ defmodule ElixirSonicClient do
     TcpConnection.recv(conn)
   end
 
-  defdelegate push(conn, collection, object, term), to: Ingest
+  def push(conn, collection, object, term) do
+    Ingest.push(conn, collection, object, term)
+  end
 
-  defdelegate count(conn, collection), to: Ingest
+  def count(conn, collection) do
+    Ingest.count(conn, collection)
+  end
 
-  defdelegate flush(conn, collection), to: Ingest
+  def flush(conn, collection) do
+    Ingest.flush(conn, collection)
+  end
 
-  defdelegate consolidate(conn), to: Control
+  def consolidate(conn) do
+    Control.consolidate(conn)
+  end
 end

--- a/lib/elixir_sonic_client.ex
+++ b/lib/elixir_sonic_client.ex
@@ -9,10 +9,13 @@ defmodule ElixirSonicClient do
   Start Connection with Sonic Server.
 
   ## Examples
-
-      iex> ElixirSonicClient.start(127.0.0.1, 1491, "search", "secret")
-      {:ok, conn}
-
+      iex> ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "search",
+        "SecretPassword"
+      )
+      {:ok, #PID<0.202.0>}
   """
   def start(host, port, mode, password) do
     {:ok, conn} = TcpConnection.start_link(host, port, [])
@@ -25,14 +28,18 @@ defmodule ElixirSonicClient do
   end
 
   @doc """
-  Start Connection with Sonic Server.
+  Stop connection with Sonic server
+  """
+  def stop(conn) do
+    TcpConnection.close(conn)
+  end
+
+  @doc """
+  Send PING message to Sonic server
 
   ## Examples
-
-      iex> {:ok, conn} = ElixirSonicClient.start(127.0.0.1, 1491, "search")
       iex> {:ok, conn} = ElixirSonicClient.ping(conn)
-      PONG
-
+      {:ok, "PONG"}
   """
   def ping(conn) do
     TcpConnection.send(conn, "PING")

--- a/lib/elixir_sonic_client.ex
+++ b/lib/elixir_sonic_client.ex
@@ -1,6 +1,7 @@
 defmodule ElixirSonicClient do
   alias ElixirSonicClient.TcpConnection
   alias ElixirSonicClient.Modes.Ingest
+  alias ElixirSonicClient.Modes.Control
 
   @moduledoc """
   Client for [Sonic search backend](https://github.com/valeriansaliou/sonic)
@@ -57,4 +58,6 @@ defmodule ElixirSonicClient do
   defdelegate count(conn, collection), to: Ingest
 
   defdelegate flush(conn, collection), to: Ingest
+
+  defdelegate consolidate(conn), to: Control
 end

--- a/lib/elixir_sonic_client.ex
+++ b/lib/elixir_sonic_client.ex
@@ -1,5 +1,6 @@
 defmodule ElixirSonicClient do
   alias ElixirSonicClient.TcpConnection
+  alias ElixirSonicClient.Modes.Ingest
 
   @moduledoc """
   Client for [Sonic search backend](https://github.com/valeriansaliou/sonic)
@@ -50,4 +51,10 @@ defmodule ElixirSonicClient do
     TcpConnection.send(conn, "PING")
     TcpConnection.recv(conn)
   end
+
+  defdelegate push(conn, collection, object, term), to: Ingest
+
+  defdelegate count(conn, collection), to: Ingest
+
+  defdelegate flush(conn, collection), to: Ingest
 end

--- a/lib/elixir_sonic_client.ex
+++ b/lib/elixir_sonic_client.ex
@@ -31,7 +31,12 @@ defmodule ElixirSonicClient do
   Stop connection with Sonic server
   """
   def stop(conn) do
-    TcpConnection.close(conn)
+    with(
+      :ok <- TcpConnection.send(conn, "QUIT"),
+      {:ok, _msg} <- TcpConnection.recv(conn)
+    ) do
+      TcpConnection.close(conn)
+    end
   end
 
   @doc """

--- a/lib/modes/control.ex
+++ b/lib/modes/control.ex
@@ -1,0 +1,17 @@
+defmodule ElixirSonicClient.Modes.Control do
+  alias ElixirSonicClient.TcpConnection
+
+  def consolidate(conn) do
+    TcpConnection.send(
+      conn,
+      "TRIGGER consolidate"
+    )
+
+    response = TcpConnection.recv(conn)
+
+    case response do
+      {:ok, "OK"} -> :ok
+      _ -> response
+    end
+  end
+end

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -13,12 +13,27 @@ defmodule ElixirSonicClient.Modes.Ingest do
 
     case response do
       {:ok, "OK"} -> :ok
-      {:error, msg} -> {:error, msg}
+      _ -> response
     end
   end
 
-  @spec count(any, any) :: nil
   def count(conn, collection) do
+    TcpConnection.send(
+      conn,
+      "COUNT #{collection}"
+    )
+
+    response = TcpConnection.recv(conn)
+
+    case response do
+      {:ok, "RESULT " <> num_str} ->
+        case Integer.parse(num_str) do
+          {num, _} -> num
+        end
+
+      _ ->
+        response
+    end
   end
 
   def flush(conn, collection) do

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -1,7 +1,7 @@
 defmodule ElixirSonicClient.Modes.Ingest do
   alias ElixirSonicClient.TcpConnection
 
-  @default_bucket_name "default_bucket"
+  @default_bucket_name "default:bucket"
 
   def push(conn, collection, object, term) do
     TcpConnection.send(
@@ -17,6 +17,7 @@ defmodule ElixirSonicClient.Modes.Ingest do
     end
   end
 
+  @spec count(any, any) :: nil
   def count(conn, collection) do
   end
 

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -1,7 +1,7 @@
 defmodule ElixirSonicClient.Modes.Ingest do
   alias ElixirSonicClient.TcpConnection
 
-  @default_bucket_name "default:bucket"
+  @default_bucket_name "default_bucket"
 
   def push(conn, collection, object, term) do
     TcpConnection.send(
@@ -37,5 +37,19 @@ defmodule ElixirSonicClient.Modes.Ingest do
   end
 
   def flush(conn, collection) do
+    TcpConnection.send(
+      conn,
+      "FLUSHC #{collection}"
+    )
+
+    response = TcpConnection.recv(conn)
+
+    case response do
+      {:ok, "RESULT " <> _num_str} ->
+        :ok
+
+      _ ->
+        response
+    end
   end
 end

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -1,0 +1,12 @@
+defmodule ElixirSonicClient.Modes.Ingest do
+  alias ElixirSonicClient.TcpConnection
+
+  def push(conn, collection, object, term) do
+  end
+
+  def count(conn, collection) do
+  end
+
+  def flush(conn, collection) do
+  end
+end

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -1,7 +1,20 @@
 defmodule ElixirSonicClient.Modes.Ingest do
   alias ElixirSonicClient.TcpConnection
 
+  @default_bucket_name "default_bucket"
+
   def push(conn, collection, object, term) do
+    TcpConnection.send(
+      conn,
+      "PUSH #{collection} #{@default_bucket_name} #{object} \"#{term}\""
+    )
+
+    response = TcpConnection.recv(conn)
+
+    case response do
+      {:ok, "OK"} -> :ok
+      {:error, msg} -> {:error, msg}
+    end
   end
 
   def count(conn, collection) do

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -31,7 +31,7 @@ defmodule ElixirSonicClient.TcpConnection do
       :ok
   """
   def send(conn, data) do
-    IO.puts("Sending \"#{data}\"")
+    # IO.puts("Sending \"#{data}\"")
     Connection.call(conn, {:send, data <> "\n"})
   end
 
@@ -48,9 +48,10 @@ defmodule ElixirSonicClient.TcpConnection do
   def recv(conn, bytes \\ 0, timeout \\ 3000) do
     response = complete_response(conn, bytes, timeout)
 
-    case response do
-      {:ok, msg} -> IO.puts("Received \"#{msg}\"")
-    end
+    # if match?({:ok, _}, response) do
+    #   {:ok, msg} = response
+    #   IO.puts("Received \"#{msg}\"")
+    # end
 
     response
   end

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -2,7 +2,6 @@ defmodule ElixirSonicClient.TcpConnection do
   @moduledoc """
   This is the TcpConnection module, responsible to send and receive calls.
   """
-  alias __MODULE__
 
   use Connection
 
@@ -64,14 +63,7 @@ defmodule ElixirSonicClient.TcpConnection do
     end
   end
 
-  def close(conn) do
-    # Connection.call(conn, :close)
-    send_response = TcpConnection.send(conn, "QUIT")
-    send_response |> inspect() |> IO.puts()
-    recv_response = recv(conn)
-    recv_response |> inspect() |> IO.puts()
-    recv_response
-  end
+  def close(conn), do: Connection.call(conn, :close)
 
   def init({host, port, opts, timeout}) do
     s = %{host: host, port: port, opts: opts, timeout: timeout, sock: nil}

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -2,8 +2,11 @@ defmodule ElixirSonicClient.TcpConnection do
   @moduledoc """
   This is the TcpConnection module, responsible to send and receive calls.
   """
+  alias __MODULE__
+
   use Connection
 
+  @spec start_link(any, any, any, any) :: :ignore | {:error, any} | {:ok, pid}
   @doc """
   Starts connection with the tcp server.
 
@@ -61,7 +64,14 @@ defmodule ElixirSonicClient.TcpConnection do
     end
   end
 
-  def close(conn), do: Connection.call(conn, :close)
+  def close(conn) do
+    # Connection.call(conn, :close)
+    send_response = TcpConnection.send(conn, "QUIT")
+    send_response |> inspect() |> IO.puts()
+    recv_response = recv(conn)
+    recv_response |> inspect() |> IO.puts()
+    recv_response
+  end
 
   def init({host, port, opts, timeout}) do
     s = %{host: host, port: port, opts: opts, timeout: timeout, sock: nil}

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -30,7 +30,10 @@ defmodule ElixirSonicClient.TcpConnection do
       iex> ElixirSonicClient.TcpConnection.send(conn, "start search password")
       :ok
   """
-  def send(conn, data), do: Connection.call(conn, {:send, data <> "\n"})
+  def send(conn, data) do
+    IO.puts("Sending \"#{data}\"")
+    Connection.call(conn, {:send, data <> "\n"})
+  end
 
   @doc """
   Receives message from the tcp server.
@@ -43,7 +46,13 @@ defmodule ElixirSonicClient.TcpConnection do
       {:ok, 'CONNECTED <sonic-server v1.3.0>\r\n'}
   """
   def recv(conn, bytes \\ 0, timeout \\ 3000) do
-    complete_response(conn, bytes, timeout)
+    response = complete_response(conn, bytes, timeout)
+
+    case response do
+      {:ok, msg} -> IO.puts("Received \"#{msg}\"")
+    end
+
+    response
   end
 
   defp complete_response(responses \\ [], conn, bytes, timeout) do

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -49,9 +49,9 @@ defmodule ElixirSonicClientTest do
         "SecretPassword"
       )
 
-    collection = "messages"
-    object = "some:object"
-    term = "Some text in it"
+    collection = "some_collection"
+    object = "some_object"
+    term = "The term."
 
     assert :ok == ElixirSonicClient.push(conn, collection, object, term)
     IO.inspect(ElixirSonicClient.count(conn, collection))

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -39,8 +39,11 @@ defmodule ElixirSonicClientTest do
     ElixirSonicClient.stop(conn)
   end
 
-  @tag :wip
   test "add data to the index" do
+    collection = "some_collection"
+    object = "some_object"
+    term = "The term."
+
     {:ok, conn} =
       ElixirSonicClient.start(
         Kernel.to_charlist("sonic"),
@@ -49,16 +52,52 @@ defmodule ElixirSonicClientTest do
         "SecretPassword"
       )
 
-    collection = "some_collection"
-    object = "some_object"
-    term = "The term."
-
     assert :ok == ElixirSonicClient.push(conn, collection, object, term)
-    IO.inspect(ElixirSonicClient.count(conn, collection))
+    ElixirSonicClient.stop(conn)
+
+    {:ok, conn} =
+      ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "control",
+        "SecretPassword"
+      )
+
+    assert :ok == ElixirSonicClient.consolidate(conn)
+    ElixirSonicClient.stop(conn)
+
+    {:ok, conn} =
+      ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "ingest",
+        "SecretPassword"
+      )
+
     assert 1 == ElixirSonicClient.count(conn, collection)
     assert :ok == ElixirSonicClient.flush(conn, collection)
-    assert 0 == ElixirSonicClient.count(conn, collection)
+    ElixirSonicClient.stop(conn)
 
+    {:ok, conn} =
+      ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "control",
+        "SecretPassword"
+      )
+
+    assert :ok == ElixirSonicClient.consolidate(conn)
+    ElixirSonicClient.stop(conn)
+
+    {:ok, conn} =
+      ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "ingest",
+        "SecretPassword"
+      )
+
+    assert 0 == ElixirSonicClient.count(conn, collection)
     ElixirSonicClient.stop(conn)
   end
 end

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -26,4 +26,17 @@ defmodule ElixirSonicClientTest do
     assert {:ok, "PONG"} == ElixirSonicClient.ping(conn)
     TcpConnection.close(conn)
   end
+
+  @tag :wip
+  test "stop" do
+    {:ok, conn} =
+      ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "search",
+        "SecretPassword"
+      )
+
+    inspect(ElixirSonicClient.stop(conn))
+  end
 end

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -50,10 +50,11 @@ defmodule ElixirSonicClientTest do
       )
 
     collection = "messages"
-    object = "the-object-it-belongs-to"
+    object = "some:object"
     term = "Some text in it"
 
     assert :ok == ElixirSonicClient.push(conn, collection, object, term)
+    IO.inspect(ElixirSonicClient.count(conn, collection))
     assert 1 == ElixirSonicClient.count(conn, collection)
     assert :ok == ElixirSonicClient.flush(conn, collection)
     assert 0 == ElixirSonicClient.count(conn, collection)

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -55,8 +55,9 @@ defmodule ElixirSonicClientTest do
 
     assert :ok == ElixirSonicClient.push(conn, collection, object, term)
     assert 1 == ElixirSonicClient.count(conn, collection)
+    assert :ok == ElixirSonicClient.flush(conn, collection)
+    assert 0 == ElixirSonicClient.count(conn, collection)
 
-    ElixirSonicClient.flush(conn, collection)
     ElixirSonicClient.stop(conn)
   end
 end

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -45,11 +45,11 @@ defmodule ElixirSonicClientTest do
       ElixirSonicClient.start(
         Kernel.to_charlist("sonic"),
         1491,
-        "search",
+        "ingest",
         "SecretPassword"
       )
 
-    collection = "some-collection"
+    collection = "messages"
     object = "the-object-it-belongs-to"
     term = "Some text in it"
 

--- a/test/elixir_sonic_client_test.exs
+++ b/test/elixir_sonic_client_test.exs
@@ -27,8 +27,7 @@ defmodule ElixirSonicClientTest do
     TcpConnection.close(conn)
   end
 
-  @tag :wip
-  test "stop" do
+  test "stop connection" do
     {:ok, conn} =
       ElixirSonicClient.start(
         Kernel.to_charlist("sonic"),
@@ -37,6 +36,27 @@ defmodule ElixirSonicClientTest do
         "SecretPassword"
       )
 
-    inspect(ElixirSonicClient.stop(conn))
+    ElixirSonicClient.stop(conn)
+  end
+
+  @tag :wip
+  test "add data to the index" do
+    {:ok, conn} =
+      ElixirSonicClient.start(
+        Kernel.to_charlist("sonic"),
+        1491,
+        "search",
+        "SecretPassword"
+      )
+
+    collection = "some-collection"
+    object = "the-object-it-belongs-to"
+    term = "Some text in it"
+
+    assert :ok == ElixirSonicClient.push(conn, collection, object, term)
+    assert 1 == ElixirSonicClient.count(conn, collection)
+
+    ElixirSonicClient.flush(conn, collection)
+    ElixirSonicClient.stop(conn)
   end
 end


### PR DESCRIPTION
## ✍️ Description
Adds basic implementation of `ElixirSonicClient`'s  `push`, `count`, `flush` and `consolidate` in order to create a basic integration test to add data to a collection for a given object with a default bucket.

Note that the integration test added has a lot of repeated code, as it needs to switch modes, consolidate and check the result of operations. This is how I managed to solve an sisue similar to this:
https://github.com/valeriansaliou/sonic/issues/225

There is still a lot of junk, here, including some commented out calls to `IO.inspect` that can be used for debugging purposes. Namely this:
https://github.com/codegram/elixir-sonic-client/pull/14/files#diff-8fbb3ff9489c856bb4d1abea1b752a38f4003a800c1debf5f2e50ef60969ff72R34
and this:
https://github.com/codegram/elixir-sonic-client/pull/14/files#diff-8fbb3ff9489c856bb4d1abea1b752a38f4003a800c1debf5f2e50ef60969ff72R51-R54

I seem to believe that it's in a good position to build upon, though. I'd reduce the scope of the ticket that motivated this PR and create new ones for the rest of the work to do in this matter (additional methods, error handling, refactoring, etc.)

What do you think, @edgarlatorre ?

## ✅ Fixes

- Closes https://github.com/codegram/elixir-sonic-client/issues/4
