### PR TITLE
[feat-17]: Unify send and recv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,7 @@
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
     "JakeBecker.elixir-ls",
+    "pgourlain.erlang",
     "ms-azuretools.vscode-docker",
     "pantajoe.vscode-elixir-credo",
     "mhutchie.git-graph",

--- a/lib/modes/control.ex
+++ b/lib/modes/control.ex
@@ -2,16 +2,11 @@ defmodule SonicClient.Modes.Control do
   alias SonicClient.TcpConnection
 
   def consolidate(conn) do
-    TcpConnection.send(
-      conn,
-      "TRIGGER consolidate"
-    )
+    command = "TRIGGER consolidate"
 
-    response = TcpConnection.recv(conn)
-
-    case response do
+    case TcpConnection.request(conn, command) do
       {:ok, "OK"} -> :ok
-      _ -> response
+      error -> error
     end
   end
 end

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -5,7 +5,6 @@ defmodule SonicClient.Modes.Ingest do
 
   def push(conn, collection, object, term) do
     command = "PUSH #{collection} #{@default_bucket_name} #{object} \"#{term}\""
-    # response = TcpConnection.request(conn, command)
 
     case TcpConnection.request(conn, command) do
       {:ok, "OK"} -> :ok
@@ -31,7 +30,7 @@ defmodule SonicClient.Modes.Ingest do
     command = "FLUSHC #{collection}"
 
     case TcpConnection.request(conn, command) do
-      {:ok, "RESULT " <> _} ->
+      {:ok, "RESULT " <> _msg} ->
         :ok
 
       error ->

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -4,7 +4,7 @@ defmodule SonicClient.Modes.Ingest do
   @default_bucket_name "default_bucket"
 
   def push(conn, collection, object, term) do
-    command = "PUSH #{collection} #{@default_bucket_name} #{object} \"#{term}\""
+    command = ~s(PUSH #{collection} #{@default_bucket_name} #{object} "#{term}")
 
     case TcpConnection.request(conn, command) do
       {:ok, "OK"} -> :ok

--- a/lib/modes/ingest.ex
+++ b/lib/modes/ingest.ex
@@ -4,52 +4,38 @@ defmodule ElixirSonicClient.Modes.Ingest do
   @default_bucket_name "default_bucket"
 
   def push(conn, collection, object, term) do
-    TcpConnection.send(
-      conn,
-      "PUSH #{collection} #{@default_bucket_name} #{object} \"#{term}\""
-    )
+    command = "PUSH #{collection} #{@default_bucket_name} #{object} \"#{term}\""
+    # response = TcpConnection.request(conn, command)
 
-    response = TcpConnection.recv(conn)
-
-    case response do
+    case TcpConnection.request(conn, command) do
       {:ok, "OK"} -> :ok
-      _ -> response
+      error -> error
     end
   end
 
   def count(conn, collection) do
-    TcpConnection.send(
-      conn,
-      "COUNT #{collection}"
-    )
+    command = "COUNT #{collection}"
 
-    response = TcpConnection.recv(conn)
-
-    case response do
+    case TcpConnection.request(conn, command) do
       {:ok, "RESULT " <> num_str} ->
         case Integer.parse(num_str) do
           {num, _} -> num
         end
 
-      _ ->
-        response
+      error ->
+        error
     end
   end
 
   def flush(conn, collection) do
-    TcpConnection.send(
-      conn,
-      "FLUSHC #{collection}"
-    )
+    command = "FLUSHC #{collection}"
 
-    response = TcpConnection.recv(conn)
-
-    case response do
-      {:ok, "RESULT " <> _num_str} ->
+    case TcpConnection.request(conn, command) do
+      {:ok, "RESULT " <> _} ->
         :ok
 
-      _ ->
-        response
+      error ->
+        error
     end
   end
 end

--- a/lib/sonic_client.ex
+++ b/lib/sonic_client.ex
@@ -19,13 +19,15 @@ defmodule SonicClient do
   def start(host, port, mode, password) do
     command = "START #{mode} #{password}"
 
-    with {:ok, conn} <- TcpConnection.open(host, port, []) do
-      case TcpConnection.request(conn, command) do
-        {:ok, "STARTED " <> _msg} -> {:ok, conn}
-        error -> error
-      end
-    else
-      error -> error
+    case TcpConnection.open(host, port, []) do
+      {:ok, conn} ->
+        case TcpConnection.request(conn, command) do
+          {:ok, "STARTED " <> _msg} -> {:ok, conn}
+          error -> error
+        end
+
+      error ->
+        error
     end
   end
 
@@ -35,9 +37,8 @@ defmodule SonicClient do
   def stop(conn) do
     command = "QUIT"
 
-    with({:ok, _msg} <- TcpConnection.request(conn, command)) do
-      TcpConnection.close(conn)
-    else
+    case TcpConnection.request(conn, command) do
+      {:ok, _msg} -> TcpConnection.close(conn)
       error -> error
     end
   end

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -22,6 +22,15 @@ defmodule ElixirSonicClient.TcpConnection do
     Connection.start_link(__MODULE__, {host, port, opts, timeout})
   end
 
+  def open(host, port, opts, timeout \\ 5000) do
+    {:ok, conn} = Connection.start_link(__MODULE__, {host, port, opts, timeout})
+
+    case build_response(conn, 0, 300) do
+      {:ok, _msg} -> {:ok, conn}
+      error -> error
+    end
+  end
+
   @doc """
   Sends a message to the tcp server.
 

--- a/test/tcp_connection_test.exs
+++ b/test/tcp_connection_test.exs
@@ -12,7 +12,10 @@ defmodule SonicClient.TcpConnectionTest do
   describe "#request" do
     test "send start search message" do
       {:ok, conn} = TcpConnection.open(host(), 1491)
-      assert {:ok, _msq} = TcpConnection.request(conn, "START search SecretPassword")
+
+      assert {:ok, "STARTED search protocol(1) buffer(20000)"} =
+               TcpConnection.request(conn, "START search SecretPassword")
+
       TcpConnection.close(conn)
     end
 

--- a/test/tcp_connection_test.exs
+++ b/test/tcp_connection_test.exs
@@ -4,43 +4,41 @@ defmodule SonicClient.TcpConnectionTest do
 
   describe "#start_link" do
     test "Successful connection" do
-      assert {:ok, conn} = TcpConnection.start_link(host(), 1491, [])
-      assert {:ok, message} = TcpConnection.recv(conn)
-      assert "CONNECTED" <> _ = message
+      {:ok, conn} = TcpConnection.open(host(), 1491)
       TcpConnection.close(conn)
     end
   end
 
-  describe "#send" do
+  describe "#request" do
     test "send start search message" do
-      {:ok, conn} = TcpConnection.start_link(host(), 1491, [])
-      assert :ok = TcpConnection.send(conn, "START search SecretPassword")
+      {:ok, conn} = TcpConnection.open(host(), 1491)
+      assert {:ok, _msq} = TcpConnection.request(conn, "START search SecretPassword")
       TcpConnection.close(conn)
     end
 
     test "send invalid mode" do
-      {:ok, conn} = TcpConnection.start_link(host(), 1491, [])
-      TcpConnection.recv(conn)
-      assert :ok = TcpConnection.send(conn, "START invalid SecretPassword")
-      assert {:ok, "ENDED invalid_mode"} = TcpConnection.recv(conn)
+      {:ok, conn} = TcpConnection.open(host(), 1491)
+
+      assert {:ok, "ENDED invalid_mode"} =
+               TcpConnection.request(conn, "START invalid SecretPassword")
+
       TcpConnection.close(conn)
     end
 
     test "send invalid command" do
       conn = connection()
-      assert :ok = TcpConnection.send(conn, "invalid command")
-      assert {:error, _} = TcpConnection.recv(conn)
+      assert {:error, _} = TcpConnection.request(conn, "invalid command")
       TcpConnection.close(conn)
     end
   end
 
   defp connection(mode \\ "search") do
-    {:ok, conn} = TcpConnection.start_link(host(), 1491, [])
-    {:ok, _msg} = TcpConnection.recv(conn)
-    :ok = TcpConnection.send(conn, "START #{mode} SecretPassword")
-    {:ok, _msg} = TcpConnection.recv(conn)
-
-    conn
+    with(
+      {:ok, conn} <- TcpConnection.open(host(), 1491),
+      {:ok, _msg} <- TcpConnection.request(conn, "START #{mode} SecretPassword")
+    ) do
+      conn
+    end
   end
 
   defp host do

--- a/test/tcp_connection_test.exs
+++ b/test/tcp_connection_test.exs
@@ -2,7 +2,7 @@ defmodule SonicClient.TcpConnectionTest do
   use ExUnit.Case
   alias SonicClient.TcpConnection
 
-  describe "#start_link" do
+  describe "#open" do
     test "Successful connection" do
       {:ok, conn} = TcpConnection.open(host(), 1491)
       TcpConnection.close(conn)


### PR DESCRIPTION
## ✍️ Description
The main changes included in this PR consist in unifiying the call pairs to `send` and `recv` into a single `request` call. Since we are implementing an application layer protocol on the client side in Elixir, I thought that it would be fine using the request-response model for the interface that we expose to the user of this library.

In addition to that, I also added the following misc changes:
- Renamed `TcpConnection. start_link ` to `TcpConnection.open` and included the `recv` step there, too.
- Renamed some functions and variables trying to better represent what they hold.
- Made some functions private.

Still outstanding.
- I decided to leave for another PR the refactor needed to expose the low level modes as modules as we discussed this morning. Need to give it a better thought and have a look at the other client libraries that you mentioned, @edgarlatorre. This way the changes in this PR will not conflict to much with the work that you may be doing for the search functions.
- Truth be told, I don't really know what I am doing with the _default_ case guards were I write `error -> error` all over the place. May read about that and would be happy to hear your advice! 

## ✅ Fixes

(optional)

- Closes #(issue) https://github.com/codegram/sonic-client/issues/17
