### PR TITLE
Implement search module

### DIFF
--- a/lib/modes/search.ex
+++ b/lib/modes/search.ex
@@ -1,0 +1,9 @@
+defmodule SonicClient.Modes.Search do
+  alias SonicClient
+  alias SonicClient.TcpConnection
+
+  def query(conn, collection, bucket, terms) do
+    command = ~s(QUERY #{collection} #{bucket} "#{terms}")
+    TcpConnection.search_request(conn, command)
+  end
+end

--- a/lib/sonic_client.ex
+++ b/lib/sonic_client.ex
@@ -19,7 +19,7 @@ defmodule SonicClient do
   def start(host, port, mode, password) do
     command = "START #{mode} #{password}"
 
-    case TcpConnection.open(host, port, []) do
+    case TcpConnection.open(host, port, mode: :binary, packet: :line) do
       {:ok, conn} ->
         case TcpConnection.request(conn, command) do
           {:ok, "STARTED " <> _msg} -> {:ok, conn}

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -45,10 +45,16 @@ defmodule SonicClient.TcpConnection do
 
   def search_request(conn, command) do
     with(
-      {:ok, "PENDING " <> marker} <- send_message(conn, command),
-      {:ok, "EVENT " <> result} <- receive_message(conn)
+      :ok <- send_message(conn, command),
+      {:ok, "PENDING " <> marker} <- receive_message(conn),
+      {:ok, "EVENT QUERY " <> result} <- receive_message(conn)
     ) do
-      {:ok, String.trim_leading(result, "#{marker}")}
+      {
+        :ok,
+        result
+        |> String.trim_leading("#{marker}")
+        |> String.split(" ", trim: true)
+      }
     else
       nil -> {:error, :invalid_options}
       reason -> {:error, reason}

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -43,6 +43,18 @@ defmodule SonicClient.TcpConnection do
     end
   end
 
+  def search_request(conn, command) do
+    with(
+      {:ok, "PENDING " <> marker} <- send_message(conn, command),
+      {:ok, "EVENT " <> result} <- receive_message(conn)
+    ) do
+      {:ok, String.trim_leading(result, "#{marker}")}
+    else
+      nil -> {:error, :invalid_options}
+      reason -> {:error, reason}
+    end
+  end
+
   def close(conn), do: Connection.call(conn, :close)
 
   defp send_message(conn, message) do

--- a/test/modes/search_test.exs
+++ b/test/modes/search_test.exs
@@ -10,14 +10,38 @@ defmodule SonicClient.Modes.SearchTest do
 
     test "returns one element" do
       add_data("user:1", "this is a test")
+      add_data("user:2", "It should not appear in the search")
       conn = start_connection("search")
       assert {:ok, ["user:1"]} = Search.query(conn, "test_collection", "default_bucket", "test")
       stop_connection(conn)
     end
 
-    test "returns none element" do
+    test "returns empty list" do
       conn = start_connection("search")
       assert {:ok, []} = Search.query(conn, "test_collection", "default_bucket", "test")
+      stop_connection(conn)
+    end
+
+    test "returns list of elements" do
+      add_data("user:1", "this is a test")
+      add_data("user:2", "this is a testable text")
+
+      conn = start_connection("search")
+
+      assert {:ok, ["user:1", "user:2"]} =
+               Search.query(conn, "test_collection", "default_bucket", "test")
+
+      stop_connection(conn)
+    end
+
+    test "returns list of elements based on alternate words" do
+      add_data("user:1", "this is a test")
+      add_data("user:2", "this is a testable text")
+
+      conn = start_connection("search")
+
+      assert {:ok, ["user:1"]} = Search.query(conn, "test_collection", "default_bucket", "tist")
+
       stop_connection(conn)
     end
   end

--- a/test/modes/search_test.exs
+++ b/test/modes/search_test.exs
@@ -1,0 +1,17 @@
+defmodule SonicClient.Modes.SearchTest do
+  use ExUnit.Case
+  alias SonicClient.Modes.Search
+  import SonicClient.TestConnectionHelper
+
+  describe "#query" do
+    test "returns elements" do
+      add_data("user:1", "this is a test")
+
+      conn = start_connection("search")
+      assert {:error, :ok} = Search.query(conn, "test_collection", "default_bucket", "test")
+      stop_connection(conn)
+
+      flush()
+    end
+  end
+end

--- a/test/modes/search_test.exs
+++ b/test/modes/search_test.exs
@@ -4,14 +4,21 @@ defmodule SonicClient.Modes.SearchTest do
   import SonicClient.TestConnectionHelper
 
   describe "#query" do
-    test "returns elements" do
-      add_data("user:1", "this is a test")
-
-      conn = start_connection("search")
-      assert {:error, :ok} = Search.query(conn, "test_collection", "default_bucket", "test")
-      stop_connection(conn)
-
+    setup do
       flush()
+    end
+
+    test "returns one element" do
+      add_data("user:1", "this is a test")
+      conn = start_connection("search")
+      assert {:ok, ["user:1"]} = Search.query(conn, "test_collection", "default_bucket", "test")
+      stop_connection(conn)
+    end
+
+    test "returns none element" do
+      conn = start_connection("search")
+      assert {:ok, []} = Search.query(conn, "test_collection", "default_bucket", "test")
+      stop_connection(conn)
     end
   end
 end

--- a/test/support/test_connection_helper.ex
+++ b/test/support/test_connection_helper.ex
@@ -15,9 +15,13 @@ defmodule SonicClient.TestConnectionHelper do
   end
 
   def add_data(object, term, collection \\ @test_collection) do
-    conn = start_connection("ingest")
-    SonicClient.push(conn, collection, object, term)
-    stop_connection(conn)
+    ingest_conn = start_connection("ingest")
+    SonicClient.push(ingest_conn, collection, object, term)
+    stop_connection(ingest_conn)
+
+    control_conn = start_connection("control")
+    SonicClient.consolidate(control_conn)
+    stop_connection(control_conn)
   end
 
   def flush(collection \\ @test_collection) do

--- a/test/support/test_connection_helper.ex
+++ b/test/support/test_connection_helper.ex
@@ -1,0 +1,36 @@
+defmodule SonicClient.TestConnectionHelper do
+  alias SonicClient
+  @test_collection "test_collection"
+
+  def start_connection(mode) do
+    {:ok, conn} =
+      SonicClient.start(
+        host(),
+        1491,
+        mode,
+        "SecretPassword"
+      )
+
+    conn
+  end
+
+  def add_data(object, term, collection \\ @test_collection) do
+    conn = start_connection("ingest")
+    SonicClient.push(conn, collection, object, term)
+    stop_connection(conn)
+  end
+
+  def flush(collection \\ @test_collection) do
+    conn = start_connection("ingest")
+    SonicClient.flush(conn, collection)
+    stop_connection(conn)
+  end
+
+  def stop_connection(conn) do
+    SonicClient.stop(conn)
+  end
+
+  defp host do
+    Kernel.to_charlist(System.get_env("SONIC_HOST", "sonic"))
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Code.require_file("test_connection_helper.ex", "test/support/")


### PR DESCRIPTION
## ✍️ Description
This is would be a first PR related to #23 it contains just a simple search, I'd like to merge it now to avoid conflicts and also because I created a connection helper for the tests so we can avoid duplicating code in our tests.

* Changed open connection to receive message as binary instead Erlang strings
* Created search module where is possible to call a simple query
* Add a TestConnectionHelper with some functions that we can reuse in our tests
