### PR TITLE
Add limit and offset to query function and implement suggest function

### DIFF
--- a/lib/modes/search.ex
+++ b/lib/modes/search.ex
@@ -5,6 +5,8 @@ defmodule SonicClient.Modes.Search do
   alias SonicClient
   alias SonicClient.TcpConnection
 
+  @default_limit 15
+
   @doc """
   Query sonic database
 
@@ -23,10 +25,25 @@ defmodule SonicClient.Modes.Search do
 
   """
   def query(conn, collection, bucket, terms, opts \\ [limit: 10, offset: 0]) do
-    limit_param = if opts[:limit], do: "LIMIT(#{opts[:limit]})", else: "LIMIT(10)"
-    offset_param = if opts[:offset], do: "OFFSET(#{opts[:offset]})", else: "OFFSET(0)"
+    command =
+      ~s(QUERY #{collection} #{bucket} "#{terms}" #{limit_from_opts(opts)} #{
+        offset_from_opts(opts)
+      })
 
-    command = ~s(QUERY #{collection} #{bucket} "#{terms}" #{limit_param} #{offset_param})
     TcpConnection.search_request(conn, command)
+  end
+
+  def suggest(conn, collection, bucket, terms, opts \\ [limit: 10]) do
+    command = ~s(SUGGEST #{collection} #{bucket} "#{terms}" #{limit_from_opts(opts)})
+
+    TcpConnection.search_request(conn, command)
+  end
+
+  defp limit_from_opts(opts) do
+    if opts[:limit], do: "LIMIT(#{opts[:limit]})", else: "LIMIT(#{@default_limit})"
+  end
+
+  defp offset_from_opts(opts) do
+    if opts[:offset], do: "OFFSET(#{opts[:offset]})", else: "OFFSET(0)"
   end
 end

--- a/lib/modes/search.ex
+++ b/lib/modes/search.ex
@@ -1,9 +1,32 @@
 defmodule SonicClient.Modes.Search do
+  @moduledoc """
+  Module to search data on sonic.
+  """
   alias SonicClient
   alias SonicClient.TcpConnection
 
-  def query(conn, collection, bucket, terms) do
-    command = ~s(QUERY #{collection} #{bucket} "#{terms}")
+  @doc """
+  Query sonic database
+
+  ## Examples
+
+  iex> {:ok, conn} = SonicClient.start(127.0.0.1, 1491, "search", "secret")
+
+  iex> SonicClient.Modes.Search.query("my_collection", "bucket", "test")
+  {:ok, ["object1", "object2"]}
+
+  iex> SonicClient.Modes.Search.query("my_collection", "bucket", "test", limit: 1)
+  {:ok, ["object1"]}
+
+  iex> SonicClient.Modes.Search.query("my_collection", "bucket", "test", limit: 1, offset: 1)
+  {:ok, ["object2"]}
+
+  """
+  def query(conn, collection, bucket, terms, opts \\ [limit: 10, offset: 0]) do
+    limit_param = if opts[:limit], do: "LIMIT(#{opts[:limit]})", else: "LIMIT(10)"
+    offset_param = if opts[:offset], do: "OFFSET(#{opts[:offset]})", else: "OFFSET(0)"
+
+    command = ~s(QUERY #{collection} #{bucket} "#{terms}" #{limit_param} #{offset_param})
     TcpConnection.search_request(conn, command)
   end
 end

--- a/lib/modes/search.ex
+++ b/lib/modes/search.ex
@@ -33,8 +33,22 @@ defmodule SonicClient.Modes.Search do
     TcpConnection.search_request(conn, command)
   end
 
-  def suggest(conn, collection, bucket, terms, opts \\ [limit: 10]) do
-    command = ~s(SUGGEST #{collection} #{bucket} "#{terms}" #{limit_from_opts(opts)})
+  @doc """
+  Search for suggestion of words for autocomplete
+
+  ## Examples
+
+  iex> {:ok, conn} = SonicClient.start(127.0.0.1, 1491, "search", "secret")
+
+  iex> SonicClient.Modes.Search.suggest("my_collection", "bucket", "te")
+  {:ok, ["test", "testable"]}
+
+  iex> SonicClient.Modes.Search.suggest("my_collection", "bucket", "te", limit: 1)
+  {:ok, ["test"]}
+
+  """
+  def suggest(conn, collection, bucket, word, opts \\ [limit: 10]) do
+    command = ~s(SUGGEST #{collection} #{bucket} "#{word}" #{limit_from_opts(opts)})
 
     TcpConnection.search_request(conn, command)
   end

--- a/lib/tcp_connection.ex
+++ b/lib/tcp_connection.ex
@@ -47,12 +47,13 @@ defmodule SonicClient.TcpConnection do
     with(
       :ok <- send_message(conn, command),
       {:ok, "PENDING " <> marker} <- receive_message(conn),
-      {:ok, "EVENT QUERY " <> result} <- receive_message(conn)
+      {:ok, "EVENT " <> result} <- receive_message(conn)
     ) do
       {
         :ok,
         result
-        |> String.trim_leading("#{marker}")
+        |> String.trim_leading("QUERY #{marker}")
+        |> String.trim_leading("SUGGEST #{marker}")
         |> String.split(" ", trim: true)
       }
     else

--- a/test/modes/search_test.exs
+++ b/test/modes/search_test.exs
@@ -3,15 +3,15 @@ defmodule SonicClient.Modes.SearchTest do
   alias SonicClient.Modes.Search
   import SonicClient.TestConnectionHelper
 
+  setup_all do
+    add_data("user:1", "It is a common test")
+    add_data("user:2", "It is a common testable text")
+    add_data("user:3", "It should not appear in the common search")
+
+    on_exit(fn -> flush() end)
+  end
+
   describe "#query" do
-    setup do
-      add_data("user:1", "It is a test")
-      add_data("user:2", "It is a testable text")
-      add_data("user:3", "It should not appear in the search")
-
-      on_exit(fn -> flush() end)
-    end
-
     test "returns empty list" do
       conn = start_connection("search")
       assert {:ok, []} = Search.query(conn, "test_collection", "default_bucket", "non-existent")
@@ -35,11 +35,32 @@ defmodule SonicClient.Modes.SearchTest do
       stop_connection(conn)
     end
 
-    test "returns list of elements with limit 1" do
+    test "returns list of elements when limit 1" do
       conn = start_connection("search")
 
       assert {:ok, ["user:1"]} =
                Search.query(conn, "test_collection", "default_bucket", "test", limit: 1)
+
+      stop_connection(conn)
+    end
+
+    test "returns list of elements when offset 1" do
+      conn = start_connection("search")
+
+      assert {:ok, ["user:2"]} =
+               Search.query(conn, "test_collection", "default_bucket", "test", offset: 1)
+
+      stop_connection(conn)
+    end
+
+    test "returns list of elements when limit 1 and offset 1" do
+      conn = start_connection("search")
+
+      assert {:ok, ["user:2"]} =
+               Search.query(conn, "test_collection", "default_bucket", "common",
+                 limit: 1,
+                 offset: 1
+               )
 
       stop_connection(conn)
     end

--- a/test/modes/search_test.exs
+++ b/test/modes/search_test.exs
@@ -5,27 +5,20 @@ defmodule SonicClient.Modes.SearchTest do
 
   describe "#query" do
     setup do
-      flush()
-    end
+      add_data("user:1", "It is a test")
+      add_data("user:2", "It is a testable text")
+      add_data("user:3", "It should not appear in the search")
 
-    test "returns one element" do
-      add_data("user:1", "this is a test")
-      add_data("user:2", "It should not appear in the search")
-      conn = start_connection("search")
-      assert {:ok, ["user:1"]} = Search.query(conn, "test_collection", "default_bucket", "test")
-      stop_connection(conn)
+      on_exit(fn -> flush() end)
     end
 
     test "returns empty list" do
       conn = start_connection("search")
-      assert {:ok, []} = Search.query(conn, "test_collection", "default_bucket", "test")
+      assert {:ok, []} = Search.query(conn, "test_collection", "default_bucket", "non-existent")
       stop_connection(conn)
     end
 
     test "returns list of elements" do
-      add_data("user:1", "this is a test")
-      add_data("user:2", "this is a testable text")
-
       conn = start_connection("search")
 
       assert {:ok, ["user:1", "user:2"]} =
@@ -35,12 +28,18 @@ defmodule SonicClient.Modes.SearchTest do
     end
 
     test "returns list of elements based on alternate words" do
-      add_data("user:1", "this is a test")
-      add_data("user:2", "this is a testable text")
-
       conn = start_connection("search")
 
       assert {:ok, ["user:1"]} = Search.query(conn, "test_collection", "default_bucket", "tist")
+
+      stop_connection(conn)
+    end
+
+    test "returns list of elements with limit 1" do
+      conn = start_connection("search")
+
+      assert {:ok, ["user:1"]} =
+               Search.query(conn, "test_collection", "default_bucket", "test", limit: 1)
 
       stop_connection(conn)
     end

--- a/test/modes/search_test.exs
+++ b/test/modes/search_test.exs
@@ -65,4 +65,24 @@ defmodule SonicClient.Modes.SearchTest do
       stop_connection(conn)
     end
   end
+
+  describe "#suggest" do
+    test "returns list of suggestions" do
+      conn = start_connection("search")
+
+      assert {:ok, ["test", "testable"]} =
+               Search.suggest(conn, "test_collection", "default_bucket", "te")
+
+      stop_connection(conn)
+    end
+
+    test "returns list of suggestions when limit 1" do
+      conn = start_connection("search")
+
+      assert {:ok, ["test"]} =
+               Search.suggest(conn, "test_collection", "default_bucket", "te", limit: 1)
+
+      stop_connection(conn)
+    end
+  end
 end


### PR DESCRIPTION
## ✍️ Description

Add limit and offset options to search and implement suggest function.

- Add limit and offset to search function
- Add suggest function to the search module which returns list of words to autocomplete

## ✅ Fixes

(optional)

- Closes #5 